### PR TITLE
Use PR title instead of commit

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -184,23 +184,21 @@ const getCombinablePRs = async function* (
       continue;
     }
 
+    const titleExtraction = pull.title.match(PR_TITLE_REGEX);
+
+    if (titleExtraction == null) {
+      logger.warning(
+        `Failed to extract version bump info from commit message: ${pull.title}`
+      );
+      continue;
+    }
+
     const { data: lastCommit } = await github.request(
       "GET /repos/{owner}/{repo}/commits/{ref}",
       apiRef
     );
 
-    const fullCommitMessage = lastCommit.commit.message;
-    const shortExtraction = fullCommitMessage.match(SHORT_MSG_REGEX);
-
-    if (shortExtraction == null) {
-      const [firstLine] = fullCommitMessage.split("\n");
-      logger.warning(
-        `Failed to extract version bump info from commit message: ${firstLine}`
-      );
-      continue;
-    }
-
-    const [shortCommitMessage, pkg, fromVersion, toVersion] = shortExtraction;
+    const [shortCommitMessage, pkg, fromVersion, toVersion] = titleExtraction;
     const pkgManagerExtraction = ref.match(PKG_MANAGER_REGEX);
 
     if (!pkgManagerExtraction) {
@@ -262,7 +260,7 @@ const cherryPickPR = async (
   }
 };
 
-const SHORT_MSG_REGEX = /bump ([\w-@\/]+) from ([\w\.-]+) to ([\w\.-]+)/i;
+const PR_TITLE_REGEX = /bump ([\w-@\/]+) from ([\w\.-]+) to ([\w\.-]+)/i;
 const PKG_MANAGER_REGEX = /dependabot\/([\w-]+)/;
 const EXTRACT_FROM_REGEX = /^\-(.*)$/m;
 const EXTRACT_TO_REGEX = /^\+(.*)$/m;


### PR DESCRIPTION
The commit may not have the version number if the package
name with it included would extend past 50 chars.

Fixes #4.