### PR TITLE
Allow Skipped option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ jobs:
           ignoreLabel: "nocombine"
           baseBranch: "main"
           openPR: true
+          allowSkipped: false
 ```
 
 These are the defaults, and any or all can be customized or omitted.

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,9 +32,11 @@ const { replaceInFile } = require("replace-in-file");
 const DEFAULT_BASE_BRANCH = "main";
 const DEFAULT_COMBINE_BRANCH_NAME = "combine-prs";
 const DEFAULT_MUST_BE_GREEN = true;
+const DEFAULT_ALLOW_SKIPPED = false;
 const DEFAULT_BRANCH_PREFIX = "dependabot";
 const DEFAULT_IGNORE_LABEL = "nocombine";
 const DEFAULT_OPEN_PR = true;
+
 
 /**
  * @param {Object} params
@@ -45,6 +47,7 @@ const DEFAULT_OPEN_PR = true;
  * @param {string} [options.baseBranch]
  * @param {string} [options.combineBranchName]
  * @param {boolean} [options.mustBeGreen]
+ * @param {boolean} [options.allowSkipped]
  * @param {string} [options.branchPrefix]
  * @param {string} [options.ignoreLabel]
  * @param {boolean} [options.openPR]
@@ -55,6 +58,7 @@ const combinePRs = async (
     baseBranch = DEFAULT_BASE_BRANCH,
     combineBranchName = DEFAULT_COMBINE_BRANCH_NAME,
     mustBeGreen = DEFAULT_MUST_BE_GREEN,
+    allowSkipped = DEFAULT_ALLOW_SKIPPED,
     branchPrefix = DEFAULT_BRANCH_PREFIX,
     ignoreLabel = DEFAULT_IGNORE_LABEL,
     openPR = DEFAULT_OPEN_PR,
@@ -70,6 +74,7 @@ const combinePRs = async (
     { github, logger, target },
     {
       mustBeGreen,
+      allowSkipped,
       branchPrefix,
       ignoreLabel,
     }
@@ -137,10 +142,12 @@ const combinePRs = async (
  * @param {string} [options.branchPrefix]
  * @param {string} [options.ignoreLabel]
  * @param {boolean} [options.mustBeGreen]
+ * @param {boolean} [options.allowSkipped]
  */
 const getCombinablePRs = async function* (
   { github, logger, target },
   {
+    allowSkipped = DEFAULT_ALLOW_SKIPPED,
     mustBeGreen = DEFAULT_MUST_BE_GREEN,
     branchPrefix = DEFAULT_BRANCH_PREFIX,
     ignoreLabel = DEFAULT_IGNORE_LABEL,
@@ -168,7 +175,16 @@ const getCombinablePRs = async function* (
         apiRef
       );
 
-      if (checks.some((check) => check.conclusion !== "success")) {
+      const isNotAllGreenOrSkipped = (check) => {
+        const { conclusion } = check;
+        const isNotSuccessfull = conclusion !== "success";
+        const isNotSkipped = conclusion !== "skipped";
+
+        return !allowSkipped ? isNotSuccessfull : isNotSuccessfull && isNotSkipped;
+      }
+
+
+      if (checks.some(isNotAllGreenOrSkipped)) {
         logger.warning(
           `Checks for ${ref} are not all successful. Not combining.`
         );


### PR DESCRIPTION
Some of our Dependabot are skipping some GitHub actions as these tests are not relevant. This makes the action fail as not all GitHub checks are green.

To solve the issue I created a new option which will accept a boolean (default false) and in case it is true allow skipped jobs to be considered as successful