### PR TITLE
fix: match `.` in the package name of the PR title

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -275,7 +275,7 @@ const cherryPickPR = async (
   }
 };
 
-const PR_TITLE_REGEX = /bump ([\w\.\-\@\/]+) from ([\w\.\-]+) to ([\w\.\-]+)/i;
+const PR_TITLE_REGEX = /bump ([\w\.-@\/]+) from ([\w\.-]+) to ([\w\.-]+)/i;
 const PKG_MANAGER_REGEX = /dependabot\/([\w-]+)/;
 const EXTRACT_FROM_REGEX = /^\-(.*)$/m;
 const EXTRACT_TO_REGEX = /^\+(.*)$/m;

--- a/lib/index.js
+++ b/lib/index.js
@@ -275,7 +275,7 @@ const cherryPickPR = async (
   }
 };
 
-const PR_TITLE_REGEX = /bump ([\w-@\/]+) from ([\w\.-]+) to ([\w\.-]+)/i;
+const PR_TITLE_REGEX = /bump ([\w\.-@\/]+) from ([\w\.-]+) to ([\w\.-]+)/i;
 const PKG_MANAGER_REGEX = /dependabot\/([\w-]+)/;
 const EXTRACT_FROM_REGEX = /^\-(.*)$/m;
 const EXTRACT_TO_REGEX = /^\+(.*)$/m;

--- a/lib/index.js
+++ b/lib/index.js
@@ -275,7 +275,7 @@ const cherryPickPR = async (
   }
 };
 
-const PR_TITLE_REGEX = /bump ([\w\.-@\/]+) from ([\w\.-]+) to ([\w\.-]+)/i;
+const PR_TITLE_REGEX = /bump ([\w\.\-\@\/]+) from ([\w\.\-]+) to ([\w\.\-]+)/i;
 const PKG_MANAGER_REGEX = /dependabot\/([\w-]+)/;
 const EXTRACT_FROM_REGEX = /^\-(.*)$/m;
 const EXTRACT_TO_REGEX = /^\+(.*)$/m;


### PR DESCRIPTION
Error message without this fix: `Warning: Failed to extract version bump info from commit message: chore(deps): bump github.com/deepmap/oapi-codegen from 1.8.3 to 1.9.1`