### PR TITLE
Add `includeLabel` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ jobs:
           branchPrefix: "dependabot"
           mustBeGreen: true
           combineBranchName: "combined-prs"
+          includeLabel: ""
           ignoreLabel: "nocombine"
           baseBranch: "main"
           openPR: true

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "Name of the branch to combine PRs into"
     required: true
     default: "combined-prs"
+  includeLabel:
+    description: "Only include PRs with this label"
+    required: false
+    default: ""
   ignoreLabel:
     description: "Exclude PRs with this label"
     required: true

--- a/action/main.js
+++ b/action/main.js
@@ -17,6 +17,7 @@ const main = async () => {
   const githubToken = core.getInput("githubToken", { required: true });
   const mustBeGreen = core.getBooleanInput("mustBeGreen", { required: true });
   const branchPrefix = core.getInput("branchPrefix", { required: true });
+  const includeLabel = core.getInput("includeLabel", { required: false });
   const ignoreLabel = core.getInput("ignoreLabel", { required: true });
   const combineBranchName = core.getInput("combineBranchName", {
     required: true,
@@ -55,6 +56,7 @@ const main = async () => {
       mustBeGreen,
       allowSkipped,
       branchPrefix,
+      includeLabel,
       ignoreLabel,
       combineBranchName,
       baseBranch,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -27,6 +27,8 @@ const cli = meow(
 	  --branch-prefix        Branch prefix to find combinable PRs based on
 	  --include-failed       Include PRs whose status checks have failed
 	  --combine-branch-name  Name of the branch to combine PRs into
+    --include-label        Only include PRs with this label
+	                         Defaults to ""
 	  --ignore-label         PR's with this label will not be combined
 	                         Defaults to "nocombine"
 	  --base-branch          Base branch to branch from & PR into
@@ -54,6 +56,10 @@ const cli = meow(
       combineBranchName: {
         type: "string",
         default: "combined-prs",
+      },
+      includeLabel: {
+        type: "string",
+        default: "",
       },
       ignoreLabel: {
         type: "string",
@@ -104,6 +110,7 @@ const TARGET_STRING_RE = /^([\w-_]+)\/([\w-_]+)$/;
   const {
     includeFailed,
     branchPrefix,
+    includeLabel,
     ignoreLabel,
     combineBranchName,
     baseBranch,
@@ -173,6 +180,7 @@ const TARGET_STRING_RE = /^([\w-_]+)\/([\w-_]+)$/;
           mustBeGreen: !includeFailed,
           allowSkipped,
           branchPrefix,
+          includeLabel,
           ignoreLabel,
           combineBranchName,
           baseBranch,

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@ const DEFAULT_COMBINE_BRANCH_NAME = "combine-prs";
 const DEFAULT_MUST_BE_GREEN = true;
 const DEFAULT_ALLOW_SKIPPED = false;
 const DEFAULT_BRANCH_PREFIX = "dependabot";
+const DEFAULT_INCLUDE_LABEL = "";
 const DEFAULT_IGNORE_LABEL = "nocombine";
 const DEFAULT_OPEN_PR = true;
 
@@ -49,6 +50,7 @@ const DEFAULT_OPEN_PR = true;
  * @param {boolean} [options.mustBeGreen]
  * @param {boolean} [options.allowSkipped]
  * @param {string} [options.branchPrefix]
+ * @param {string} [options.includeLabel]
  * @param {string} [options.ignoreLabel]
  * @param {boolean} [options.openPR]
  */
@@ -60,6 +62,7 @@ const combinePRs = async (
     mustBeGreen = DEFAULT_MUST_BE_GREEN,
     allowSkipped = DEFAULT_ALLOW_SKIPPED,
     branchPrefix = DEFAULT_BRANCH_PREFIX,
+    includeLabel = DEFAULT_INCLUDE_LABEL,
     ignoreLabel = DEFAULT_IGNORE_LABEL,
     openPR = DEFAULT_OPEN_PR,
   } = {}
@@ -77,6 +80,7 @@ const combinePRs = async (
       allowSkipped,
       branchPrefix,
       ignoreLabel,
+      includeLabel,
     }
   );
 
@@ -121,7 +125,7 @@ const combinePRs = async (
     const response = await github.rest.pulls.create({
       owner: target.owner,
       repo: target.repo,
-      title: "Update combined dependencies",
+      title: includeLabel ? `Update combined ${includeLabel} dependencies` : "Update combined dependencies",
       head: combineBranchName,
       base: baseBranch,
       body: body,
@@ -140,6 +144,7 @@ const combinePRs = async (
  * @param {Target} params.target
  * @param {Object} [options]
  * @param {string} [options.branchPrefix]
+ * @param {string} [options.includeLabel]
  * @param {string} [options.ignoreLabel]
  * @param {boolean} [options.mustBeGreen]
  * @param {boolean} [options.allowSkipped]
@@ -151,6 +156,7 @@ const getCombinablePRs = async function* (
     allowSkipped = DEFAULT_ALLOW_SKIPPED,
     branchPrefix = DEFAULT_BRANCH_PREFIX,
     ignoreLabel = DEFAULT_IGNORE_LABEL,
+    includeLabel = DEFAULT_INCLUDE_LABEL,
   } = {}
 ) {
   const pulls = await github.paginate(
@@ -196,6 +202,14 @@ const getCombinablePRs = async function* (
       pull.labels.some((label) => label.name === ignoreLabel)
     ) {
       logger.warning(`${ref} has label ${ignoreLabel}. Not combining.`);
+      continue;
+    }
+
+    if (
+      includeLabel &&
+      !pull.labels.some((label) => label.name === includeLabel)
+    ) {
+      logger.warning(`${ref} doesn't have label ${includeLabel}. Not combining.`);
       continue;
     }
 


### PR DESCRIPTION
This PR adds a new option `includeLabel` which provides the opposite behaviour of the existing `ignoreLabel` option. This can be useful for having this action only combine PRs for a given package ecosystem for example.