### PR TITLE
Fix: match `-` in PR title

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -289,7 +289,7 @@ const cherryPickPR = async (
   }
 };
 
-const PR_TITLE_REGEX = /bump ([\w\.-@\/]+) from ([\w\.-]+) to ([\w\.-]+)/i;
+const PR_TITLE_REGEX = /bump ([\w\.\-@\/]+) from ([\w\.-]+) to ([\w\.-]+)/i;
 const PKG_MANAGER_REGEX = /dependabot\/([\w-]+)/;
 const EXTRACT_FROM_REGEX = /^\-(.*)$/m;
 const EXTRACT_TO_REGEX = /^\+(.*)$/m;


### PR DESCRIPTION
Hello 👋 
Thanks for the work on this repo, super helpful!

I ran into this issue:
`Failed to extract version bump info from commit message: Bump @aws-sdk/client-dynamodb from 3.100.0 to 3.105.0`
It seems to come from the hyphen in the PR title version. Escaping the `-` seems to fix it.