### PR TITLE
Add new option `closeOnceCombined`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ jobs:
           baseBranch: "main"
           openPR: true
           allowSkipped: false
+          closeOnceCombined: false
 ```
 
 These are the defaults, and any or all can be customized or omitted.

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: "Whether to treat skipped checks as successful"
     default: false
     required: false
+  closeOnceCombined:
+    description: "Whether to close dependabot PRs once they have been combined"
+    default: false
+    required: false
 runs:
   using: "node12"
   pre: "action/pre.js"

--- a/action/main.js
+++ b/action/main.js
@@ -25,6 +25,7 @@ const main = async () => {
   const baseBranch = core.getInput("baseBranch", { required: true });
   const openPR = core.getBooleanInput("openPR", { required: true });
   const allowSkipped = core.getBooleanInput("allowSkipped", { required: false });
+  const closeOnceCombined = core.getBooleanInput("closeOnceCombined", { required: false });
   const github = getOctokit(githubToken);
 
   await execa("git", ["config", "user.name", "github-actions"]);
@@ -61,6 +62,7 @@ const main = async () => {
       combineBranchName,
       baseBranch,
       openPR,
+      closeOnceCombined,
     }
   );
 };

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -35,6 +35,7 @@ const cli = meow(
 	                         Defaults to "main"
     --allow-skipped        Allow skipped checks to be considered succesful
 	  --skip-pr              If present, will skip creating a new PR for the new branch
+    --close-once-combined  If present, will close the individual dependabot PRs/branchs once combined
 
 	Examples
 	  $ combine-dependabot-prs mAAdhaTTah/memezer
@@ -77,6 +78,10 @@ const cli = meow(
         type: "boolean",
         default: false,
       },
+      closeOnceCombined: {
+        type: "boolean",
+        default: false,
+      },
     },
   }
 );
@@ -116,6 +121,7 @@ const TARGET_STRING_RE = /^([\w-_]+)\/([\w-_]+)$/;
     baseBranch,
     skipPr,
     allowSkipped,
+    closeOnceCombined,
   } = cli.flags;
   let { githubToken } = cli.flags;
 
@@ -185,6 +191,7 @@ const TARGET_STRING_RE = /^([\w-_]+)\/([\w-_]+)$/;
           combineBranchName,
           baseBranch,
           openPR: !skipPr,
+          closeOnceCombined,
         }
       );
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ const DEFAULT_BRANCH_PREFIX = "dependabot";
 const DEFAULT_INCLUDE_LABEL = "";
 const DEFAULT_IGNORE_LABEL = "nocombine";
 const DEFAULT_OPEN_PR = true;
+const DEFAULT_CLOSE_ONCE_COMBINED = false;
 
 
 /**
@@ -53,6 +54,7 @@ const DEFAULT_OPEN_PR = true;
  * @param {string} [options.includeLabel]
  * @param {string} [options.ignoreLabel]
  * @param {boolean} [options.openPR]
+ * @param {boolean} [options.closeOnceCombined]
  */
 const combinePRs = async (
   { github, logger, target },
@@ -65,6 +67,7 @@ const combinePRs = async (
     includeLabel = DEFAULT_INCLUDE_LABEL,
     ignoreLabel = DEFAULT_IGNORE_LABEL,
     openPR = DEFAULT_OPEN_PR,
+    closeOnceCombined = DEFAULT_CLOSE_ONCE_COMBINED,
   } = {}
 ) => {
   logger.info(`Setting up repository for committing.`);
@@ -85,6 +88,10 @@ const combinePRs = async (
   );
 
   let prString = "";
+  /**
+   * @type {{ ref: any; number: any; title: any; lastCommit: any; shortCommitMessage: any; pkg: any; fromVersion: any; toVersion: any; manager: any; }[]}
+   */
+  const combinedPRs = [];
 
   for await (const pr of combinablePRs) {
     await logger.group(
@@ -106,6 +113,7 @@ const combinePRs = async (
             `Successfully updated ${pr.pkg} from ${pr.fromVersion} to ${pr.toVersion}.`
           );
           prString += "* #" + pr.number + " " + pr.title + "\n";
+          combinedPRs.push(pr);
         } catch (err) {
           logger.error(
             `Failed to apply "${pr.title}" due to error:\n\n${
@@ -134,6 +142,32 @@ const combinePRs = async (
     logger.success(
       terminalLink(`Successfully opened PR`, response.data.html_url)
     );
+
+    if(closeOnceCombined)
+    {
+      for (const pr of combinedPRs) {
+        try {
+          await github.rest.pulls.update({
+            owner: target.owner,
+            repo: target.repo,
+            pull_number: pr.number,
+            state: "closed",
+          });
+  
+          await github.rest.git.deleteRef({
+            owner: target.owner,
+            repo: target.repo,
+            ref: pr.ref,
+          });
+        } catch (err) {
+          logger.error(
+            `Failed to close "${pr.title}" due to error:\n\n${
+              err.message || err
+            }`
+          );
+        }
+      }
+    }
   }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -217,18 +217,13 @@ const getCombinablePRs = async function* (
         apiRef
       );
       
-      console.info("allowSkipped", allowSkipped);
-
       const isNotAllGreenOrSkipped = (check) => {
         const { conclusion } = check;
-        console.info("conclusion", conclusion);
         const isSuccessful = conclusion === "success";
-        const isSkipped = conclusion === "skipped";
+        const isSkipped = conclusion === "neutral";
         const isAllGreenOrSkipped = !allowSkipped ? isSuccessful : isSuccessful || isSkipped;
         return !isAllGreenOrSkipped;
       }
-      
-      console.info(checks[0]);
 
       if (checks.some(isNotAllGreenOrSkipped)) {
         logger.warning(

--- a/lib/index.js
+++ b/lib/index.js
@@ -124,44 +124,52 @@ const combinePRs = async (
       }
     );
   }
+  
+  if(combinedPRs.length > 0)
+  {
+    await execa("git", ["push", "origin", combineBranchName]);
 
-  await execa("git", ["push", "origin", combineBranchName]);
+    if (openPR) {
+      const body = `This PR was created by the Combine PRs action by combining the following PRs:\n\n${prString}`;
 
-  if (openPR) {
-    const body = `This PR was created by the Combine PRs action by combining the following PRs:\n\n${prString}`;
+      const response = await github.rest.pulls.create({
+        owner: target.owner,
+        repo: target.repo,
+        title: includeLabel ? `Update combined ${includeLabel} dependencies` : "Update combined dependencies",
+        head: combineBranchName,
+        base: baseBranch,
+        body: body,
+      });
 
-    const response = await github.rest.pulls.create({
-      owner: target.owner,
-      repo: target.repo,
-      title: includeLabel ? `Update combined ${includeLabel} dependencies` : "Update combined dependencies",
-      head: combineBranchName,
-      base: baseBranch,
-      body: body,
-    });
+      logger.success(
+        terminalLink(`Successfully opened PR`, response.data.html_url)
+      );
 
-    logger.success(
-      terminalLink(`Successfully opened PR`, response.data.html_url)
-    );
-
-    if(closeOnceCombined)
-    {
-      for (const pr of combinedPRs) {
-        try {
-          await github.rest.pulls.update({
-            owner: target.owner,
-            repo: target.repo,
-            pull_number: pr.number,
-            state: "closed",
-          });
-        } catch (err) {
-          logger.error(
-            `Failed to close "${pr.title}" due to error:\n\n${
-              err.message || err
-            }`
-          );
+      if(closeOnceCombined)
+      {
+        for (const pr of combinedPRs) {
+          try {
+            await github.rest.pulls.update({
+              owner: target.owner,
+              repo: target.repo,
+              pull_number: pr.number,
+              state: "closed",
+            });
+          } catch (err) {
+            logger.error(
+              `Failed to close "${pr.title}" due to error:\n\n${
+                err.message || err
+              }`
+            );
+          }
         }
       }
     }
+  }
+  
+  else
+  {
+    logger.warning("Nothing to combine");
   }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -174,6 +174,43 @@ const combinePRs = async (
 };
 
 /**
+ * @param {string} targetLabel
+ * @param {Object} pull
+ * @returns {boolean}
+ */
+const filterMatchingPatternLabel = (targetLabel, pull) =>
+{
+  const includeLabels = targetLabel.split(",").map(label => /\|/.test(label) ? label.split("|") : label);
+  const prLabels = pull.labels.map(label => label.name);
+  const matchedLabels = [];
+
+  prLabels.forEach(prLabel =>
+  {
+      includeLabels.forEach(includeLabel =>
+      {
+        if(Array.isArray(includeLabel) && includeLabel.some(label => label == prLabel))
+        {
+            matchedLabels.push(prLabel);
+        }
+        
+        else if(includeLabel == prLabel)
+        {
+            matchedLabels.push(prLabel);
+        }
+      });    
+  });
+
+  return matchedLabels.length == includeLabels.length;
+};
+
+/**
+ * @param {string} targetLabel
+ * @param {Object} pull
+ * @returns {boolean}
+ */
+const filterMatchingStringLabel = (targetLabel, pull) => pull.labels.some(label => label.name === targetLabel);
+
+/**
  * @param {Object} params
  * @param {GitHub} params.github
  * @param {Logger} params.logger
@@ -233,20 +270,26 @@ const getCombinablePRs = async function* (
       }
     }
 
-    if (
-      ignoreLabel &&
-      pull.labels.some((label) => label.name === ignoreLabel)
-    ) {
-      logger.warning(`${ref} has label ${ignoreLabel}. Not combining.`);
-      continue;
+    if (ignoreLabel)
+    {
+      const matchingPrs = /,|\|/.test(ignoreLabel) ? filterMatchingPatternLabel(ignoreLabel, pull) : filterMatchingStringLabel(ignoreLabel, pull);
+
+      if(matchingPrs)
+      {
+        logger.warning(`${ref} has label ${ignoreLabel}. Not combining.`);
+        continue;  
+      }
     }
 
-    if (
-      includeLabel &&
-      !pull.labels.some((label) => label.name === includeLabel)
-    ) {
-      logger.warning(`${ref} doesn't have label ${includeLabel}. Not combining.`);
-      continue;
+    if (includeLabel)
+    {
+      const matchingPrs = /,|\|/.test(ignoreLabel) ? !filterMatchingPatternLabel(includeLabel, pull) : !filterMatchingStringLabel(includeLabel, pull);
+
+      if(matchingPrs)
+      {
+        logger.warning(`${ref} doesn't have label ${includeLabel}. Not combining.`);
+        continue;  
+      }
     }
 
     const titleExtraction = pull.title.match(PR_TITLE_REGEX);

--- a/lib/index.js
+++ b/lib/index.js
@@ -283,7 +283,7 @@ const getCombinablePRs = async function* (
 
     if (includeLabel)
     {
-      const matchingPrs = /,|\|/.test(ignoreLabel) ? !filterMatchingPatternLabel(includeLabel, pull) : !filterMatchingStringLabel(includeLabel, pull);
+      const matchingPrs = /,|\|/.test(includeLabel) ? !filterMatchingPatternLabel(includeLabel, pull) : !filterMatchingStringLabel(includeLabel, pull);
 
       if(matchingPrs)
       {

--- a/lib/index.js
+++ b/lib/index.js
@@ -153,12 +153,6 @@ const combinePRs = async (
             pull_number: pr.number,
             state: "closed",
           });
-  
-          await github.rest.git.deleteRef({
-            owner: target.owner,
-            repo: target.repo,
-            ref: pr.ref,
-          });
         } catch (err) {
           logger.error(
             `Failed to close "${pr.title}" due to error:\n\n${

--- a/lib/index.js
+++ b/lib/index.js
@@ -216,14 +216,19 @@ const getCombinablePRs = async function* (
         "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
         apiRef
       );
+      
+      console.info("allowSkipped", allowSkipped);
 
       const isNotAllGreenOrSkipped = (check) => {
         const { conclusion } = check;
-        const isSuccessfull = conclusion === "success";
+        console.info("conclusion", conclusion);
+        const isSuccessful = conclusion === "success";
         const isSkipped = conclusion === "skipped";
-        const isAllGreenOrSkipped = !allowSkipped ? isSuccessfull : isSuccessfull || isSkipped;
+        const isAllGreenOrSkipped = !allowSkipped ? isSuccessful : isSuccessful || isSkipped;
         return !isAllGreenOrSkipped;
       }
+      
+      console.info(checks[0]);
 
       if (checks.some(isNotAllGreenOrSkipped)) {
         logger.warning(


### PR DESCRIPTION
This PR adds a new option `closeOnceCombined` which will close individual dependabot PRs once they have been combined in the new PR.